### PR TITLE
Upload files to Synapse

### DIFF
--- a/create_project.R
+++ b/create_project.R
@@ -1,0 +1,43 @@
+#######################################
+####  Create project to log files  ####
+#######################################
+
+library("synapser")
+synLogin()
+new_proj <- Project("AMP-AD validation")
+new_proj_id <- synStore(new_proj)
+
+## Give dcctravistest CREATE, UPDATE, and READ (for testing purposes)
+synSetPermissions(
+  entity = new_proj_id$properties$id,
+  principalId = "3384770",
+  accessType = list("CREATE", "READ", "UPDATE")
+)
+
+## Give AMP-AD_SageCuration team edit and delete access
+synSetPermissions(
+  entity = new_proj_id$properties$id,
+  principalId = "3346847",
+  accessType = list("CREATE", "READ", "DOWNLOAD", "UPDATE", "DELETE")
+)
+
+## Give Mette additional permissions
+synSetPermissions(
+  entity = new_proj_id$properties$id,
+  principalId = "273995",
+  accessType = list(
+    "CREATE",
+    "READ",
+    "DOWNLOAD",
+    "UPDATE",
+    "DELETE",
+    "CHANGE_PERMISSIONS"
+  )
+)
+
+## Give AMP-AD consortium team CREATE, UPDATE, and READ
+synSetPermissions(
+  entity = new_proj_id$properties$id,
+  principalId = "3320424",
+  accessType = list("CREATE", "READ", "UPDATE")
+)

--- a/global.R
+++ b/global.R
@@ -84,29 +84,12 @@ show_details.list <- function(x) {
   renderTable(dat, colnames = FALSE)
 }
 
-## Rename uploaded files back to their original name (so they get saved to
-## synapse with the correct name)
-rename_uploaded_file <- function(x) {
-  if (is.null(x)) {
-    return()
-  }
-
-  ## new <- file.path(dirname(x$datapath), x$name)
-  new <- get_new_file_path(x)
-  file.rename(from = x$datapath, to = new)
-  x$datapath <- new
-  x
-}
-
-## Generate new file name from input (this is used in `rename_uploaded_file()`
-## and also used directly in the app so that it can read in data after it has
-## been renamed)
-get_new_file_path <- function(input) {
-  file.path(dirname(input$datapath), input$name)
-}
-
 ## Save uploaded files to Synapse
-save_to_synapse <- function(input_file, parent) {
-  file_to_upload <- File(input_file$datapath, parent = parent)
+save_to_synapse <- function(input_file, parent, name = NULL) {
+  file_to_upload <- File(
+    input_file$datapath,
+    parent = parent,
+    name = name
+  )
   synStore(file_to_upload)
 }

--- a/global.R
+++ b/global.R
@@ -83,3 +83,30 @@ show_details.list <- function(x) {
   })
   renderTable(dat, colnames = FALSE)
 }
+
+## Rename uploaded files back to their original name (so they get saved to
+## synapse with the correct name)
+rename_uploaded_file <- function(x) {
+  if (is.null(x)) {
+    return()
+  }
+
+  ## new <- file.path(dirname(x$datapath), x$name)
+  new <- get_new_file_path(x)
+  file.rename(from = x$datapath, to = new)
+  x$datapath <- new
+  x
+}
+
+## Generate new file name from input (this is used in `rename_uploaded_file()`
+## and also used directly in the app so that it can read in data after it has
+## been renamed)
+get_new_file_path <- function(input) {
+  file.path(dirname(input$datapath), input$name)
+}
+
+## Save uploaded files to Synapse
+save_to_synapse <- function(input_file, parent) {
+  file_to_upload <- File(input_file$datapath, parent = parent)
+  synStore(file_to_upload)
+}

--- a/server.R
+++ b/server.R
@@ -25,30 +25,42 @@ server <- function(input, output, session) {
     ## Upload files to Synapse (after renaming them so they keep their original
     ## names)
     observeEvent(input$manifest, {
-      m <- rename_uploaded_file(input$manifest)
-      save_to_synapse(m, parent = created_folder)
+      save_to_synapse(
+        input$manifest,
+        parent = created_folder,
+        name = input$manifest$name
+      )
     })
 
     observeEvent(input$indiv_meta, {
-      i <- rename_uploaded_file(input$indiv_meta)
-      save_to_synapse(i, parent = created_folder)
+      save_to_synapse(
+        input$indiv_meta,
+        parent = created_folder,
+        name = input$indiv_meta$name
+      )
     })
 
     observeEvent(input$biosp_meta, {
-      b <- rename_uploaded_file(input$biosp_meta)
-      save_to_synapse(b, parent = created_folder)
+      save_to_synapse(
+        input$biosp_meta,
+        parent = created_folder,
+        name = input$biosp_meta$name
+      )
     })
 
     observeEvent(input$assay_meta, {
-      a <- rename_uploaded_file(input$assay_meta)
-      save_to_synapse(a, parent = created_folder)
+      save_to_synapse(
+        input$assay_meta,
+        parent = created_folder,
+        name = input$assay_meta$name
+      )
     })
 
     ## Load metadata files into session
     manifest <- reactive({
       validate(need(input$manifest, "Please upload manifest file"))
       read.table(
-        get_new_file_path(input$manifest),
+        input$manifest$datapath,
         sep = "\t",
         header = TRUE,
         na.strings = ""
@@ -56,15 +68,15 @@ server <- function(input, output, session) {
     })
     indiv <- reactive({
       validate(need(input$indiv_meta, "Upload individual metadata"))
-      read.csv(get_new_file_path(input$indiv_meta))
+      read.csv(input$indiv_meta$datapath)
     })
     biosp <- reactive({
       validate(need(input$biosp_meta, "Upload biospecimen metadata"))
-      read.csv(get_new_file_path(input$biosp_meta))
+      read.csv(input$biosp_meta$datapath)
     })
     assay <- reactive({
       validate(need(input$assay_meta, "Upload assay metadata"))
-      read.csv(get_new_file_path(input$assay_meta))
+      read.csv(input$assay_meta$datapath)
     })
     species_name <- reactive({input$species})
     assay_name <- reactive({input$assay})

--- a/server.R
+++ b/server.R
@@ -21,19 +21,34 @@ server <- function(input, output, session) {
     user <- synGetUserProfile()
     new_folder <- Folder(name = user$get("userName"), parent = "syn20400157")
     created_folder <- synStore(new_folder)
-    ## figure out how to set folder permissions here
 
-    # Load data files
+    ## Upload files to Synapse (after renaming them so they keep their original
+    ## names)
+    observeEvent(input$manifest, {
+      m <- rename_uploaded_file(input$manifest)
+      save_to_synapse(m, parent = created_folder)
+    })
+
+    observeEvent(input$indiv_meta, {
+      i <- rename_uploaded_file(input$indiv_meta)
+      save_to_synapse(i, parent = created_folder)
+    })
+
+    observeEvent(input$biosp_meta, {
+      b <- rename_uploaded_file(input$biosp_meta)
+      save_to_synapse(b, parent = created_folder)
+    })
+
+    observeEvent(input$assay_meta, {
+      a <- rename_uploaded_file(input$assay_meta)
+      save_to_synapse(a, parent = created_folder)
+    })
+
+    ## Load metadata files into session
     manifest <- reactive({
       validate(need(input$manifest, "Please upload manifest file"))
-
-      ## Upload
-      file_to_upload <- File(input$manifest$datapath, parent = created_folder)
-      synStore(file_to_upload)
-
-      ## Read in data
       read.table(
-        input$manifest$datapath,
+        get_new_file_path(input$manifest),
         sep = "\t",
         header = TRUE,
         na.strings = ""
@@ -41,15 +56,15 @@ server <- function(input, output, session) {
     })
     indiv <- reactive({
       validate(need(input$indiv_meta, "Upload individual metadata"))
-      indiv <- read.csv(input$indiv_meta$datapath)
+      read.csv(get_new_file_path(input$indiv_meta))
     })
     biosp <- reactive({
       validate(need(input$biosp_meta, "Upload biospecimen metadata"))
-      biosp <- read.csv(input$biosp_meta$datapath)
+      read.csv(get_new_file_path(input$biosp_meta))
     })
     assay <- reactive({
       validate(need(input$assay_meta, "Upload assay metadata"))
-      assay <- read.csv(input$assay_meta$datapath)
+      read.csv(get_new_file_path(input$assay_meta))
     })
     species_name <- reactive({input$species})
     assay_name <- reactive({input$assay})

--- a/server.R
+++ b/server.R
@@ -19,7 +19,7 @@ server <- function(input, output, session) {
 
     ## Create folder for upload
     user <- synGetUserProfile()
-    new_folder <- Folder(name = user$get("userName"), parent = "syn20400157")
+    new_folder <- Folder(name = user$get("userName"), parent = "syn20506363")
     created_folder <- synStore(new_folder)
 
     ## Upload files to Synapse (after renaming them so they keep their original

--- a/server.R
+++ b/server.R
@@ -17,9 +17,21 @@ server <- function(input, output, session) {
     ## Download annotation definitions
     annots <- get_synapse_annotations()
 
+    ## Create folder for upload
+    user <- synGetUserProfile()
+    new_folder <- Folder(name = user$get("userName"), parent = "syn20400157")
+    created_folder <- synStore(new_folder)
+    ## figure out how to set folder permissions here
+
     # Load data files
     manifest <- reactive({
       validate(need(input$manifest, "Please upload manifest file"))
+
+      ## Upload
+      file_to_upload <- File(input$manifest$datapath, parent = created_folder)
+      synStore(file_to_upload)
+
+      ## Read in data
       read.table(
         input$manifest$datapath,
         sep = "\t",


### PR DESCRIPTION
To allow the curation team to review metadata that has been uploaded. This is purely to avoid having files linger on the shiny server while still allowing curators to review/validate. Contributors will still upload the files to Synapse the normal way separately. Closes #21, closes #32 