### PR TITLE
Check data even when incomplete

### DIFF
--- a/server.R
+++ b/server.R
@@ -58,7 +58,7 @@ server <- function(input, output, session) {
 
     ## Load metadata files into session
     manifest <- reactive({
-      validate(need(input$manifest, "Please upload manifest file"))
+      if (is.null(input$manifest)) return(NULL)
       read.table(
         input$manifest$datapath,
         sep = "\t",
@@ -67,15 +67,15 @@ server <- function(input, output, session) {
       )
     })
     indiv <- reactive({
-      validate(need(input$indiv_meta, "Upload individual metadata"))
+      if (is.null(input$indiv_meta)) return(NULL)
       read.csv(input$indiv_meta$datapath, na.strings = "")
     })
     biosp <- reactive({
-      validate(need(input$biosp_meta, "Upload biospecimen metadata"))
+      if (is.null(input$biosp_meta)) return(NULL)
       read.csv(input$biosp_meta$datapath, na.strings = "")
     })
     assay <- reactive({
-      validate(need(input$assay_meta, "Upload assay metadata"))
+      if (is.null(input$assay_meta)) return(NULL)
       read.csv(input$assay_meta$datapath, na.strings = "")
     })
     species_name <- reactive({input$species})

--- a/server.R
+++ b/server.R
@@ -244,14 +244,25 @@ server <- function(input, output, session) {
     inputs <- reactiveVal(c())
 
     ## Reactive list of data
-    vals <- reactive(
+    vals <- reactive({
+      validate(
+        need(
+          any(
+            !is.null(indiv()),
+            !is.null(biosp()),
+            !is.null(assay()),
+            !is.null(manifest())
+          ),
+          message = "Please upload some data to view a summary"
+        )
+      )
       list(
         "Individual metadata" = indiv(),
         "Biospecimen metadata" = biosp(),
         "Assay metadata" = assay(),
         "Manifest file" = manifest()
       )
-    )
+    })
 
     ## Update selectInput options for which data files to summarize
     observe({
@@ -289,11 +300,27 @@ server <- function(input, output, session) {
           p100 = NULL
         )
       )
+      ## Validate the data again, otherwise when the user first inputs data an
+      ## error will flash briefly
+      validate(
+        need(
+          !is.null((vals()[[input$file_to_summarize]])),
+          message = FALSE
+        )
+      )
       skim(vals()[[input$file_to_summarize]])
     })
 
     ## visdat summary figure
     output$datafilevisdat <- renderPlot({
+      ## Validate the data again, otherwise when the user first inputs data an
+      ## error will flash briefly
+      validate(
+        need(
+          !is.null((vals()[[input$file_to_summarize]])),
+          message = FALSE
+        )
+      )
       vis_dat(vals()[[input$file_to_summarize]]) +
         theme(text = element_text(size = 16))
     })

--- a/ui.R
+++ b/ui.R
@@ -120,13 +120,7 @@ ui <- function(request) {
                   selectInput(
                     "file_to_summarize",
                     label = "Choose file to view",
-                    choices = list(
-                      "Individual metadata" = "indiv",
-                      "Biospecimen metadata" = "biosp",
-                      "Assay metadata" = "assay",
-                      "Manifest file" = "manifest"
-                      ),
-                    selected = "indiv"
+                    choices = c("")
                   ),
                   hr(),
                   plotOutput("datafilevisdat"),


### PR DESCRIPTION
Perform checks for whatever files are uploaded, even if not all files have been uploaded. For the data summary, the `selectInput` options are determined based on which files have been uploaded. This PR will be useful for addressing #27.